### PR TITLE
Replace hard coded versions with variables

### DIFF
--- a/packages/babel-plugin-version-injector/.eslintrc.yml
+++ b/packages/babel-plugin-version-injector/.eslintrc.yml
@@ -1,0 +1,5 @@
+env:
+  node: true
+
+rules:
+  flowtype/require-valid-file-annotation: off

--- a/packages/babel-plugin-version-injector/index.js
+++ b/packages/babel-plugin-version-injector/index.js
@@ -1,0 +1,33 @@
+const { devDependencies } = require('../../package');
+const { name } = require('./package');
+
+// Freighter itself uses freighter. It's the model from which the framework is
+// built. Because of that, the library versions of the root package.json have
+// to be kept in sync with the generated package.json. That's tedious.
+//
+// This babel plugin automates the process by exposing a special
+// `__VERSIONS__` global at compile time, making it possible to dynamically
+// inject the library versions from freighter's monorepo package.
+module.exports = function({ types }) {
+  return {
+    name,
+    visitor: {
+      MemberExpression(path) {
+        const { object, property } = path.node;
+        if (object.name !== '__VERSIONS__') return;
+
+        // Work with both bracket and dot syntax.
+        const libraryName = property.name || property.value;
+
+        if (!(libraryName in devDependencies)) {
+          throw path.buildCodeFrameError(
+            `'${libraryName}' doesn't exist in freighter's package.`
+          );
+        }
+
+        const version = devDependencies[libraryName];
+        path.replaceWith(types.stringLiteral(version));
+      },
+    },
+  };
+};

--- a/packages/babel-plugin-version-injector/package.json
+++ b/packages/babel-plugin-version-injector/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@freighter/babel-plugin-version-injector",
+  "version": "0.3.4",
+  "description": "Synchronize library versions between templates and the freighter monorepo",
+  "main": "index.js",
+  "repository": "https://github.com/PsychoLlama/freighter.git",
+  "author": "Jesse Gibson <JesseTheGibson@gmail.com>",
+  "license": "MIT",
+  "private": true
+}

--- a/packages/cli/.babelrc
+++ b/packages/cli/.babelrc
@@ -1,3 +1,4 @@
 {
-  "extends": "../../babel.config"
+  "extends": "../../babel.config",
+  "plugins": ["@freighter/babel-plugin-version-injector"]
 }

--- a/packages/cli/.eslintrc.yml
+++ b/packages/cli/.eslintrc.yml
@@ -1,2 +1,5 @@
+globals:
+  __VERSIONS__: false
+
 env:
   node: true

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,6 +13,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "devDependencies": {
+    "@freighter/babel-plugin-version-injector": "*"
+  },
   "dependencies": {
     "@babel/cli": "7.4.4",
     "@babel/core": "7.4.5",
@@ -29,5 +32,8 @@
     "lerna": "3.15.0",
     "lint-staged": "8.2.1",
     "promisify-child-process": "^3.1.0"
+  },
+  "jest": {
+    "setupFiles": ["./src/setupTests.js"]
   }
 }

--- a/packages/cli/src/setupTests.js
+++ b/packages/cli/src/setupTests.js
@@ -1,0 +1,2 @@
+// @flow
+global.__VERSIONS__ = new Proxy({}, { get: (_, key) => key });

--- a/packages/cli/src/templates/package-json.js
+++ b/packages/cli/src/templates/package-json.js
@@ -30,17 +30,27 @@ export default ({ projectName, versions }: PackageVariables) =>
     },
     workspaces: ['packages/*'],
     devDependencies: {
-      '@babel/cli': '7.4.4',
-      '@babel/core': '7.4.5',
+      // $FlowFixMe
+      '@babel/cli': __VERSIONS__['@babel/cli'],
+      // $FlowFixMe
+      '@babel/core': __VERSIONS__['@babel/core'],
       '@freighter/scripts': versions.freighterScripts,
       'eslint-config-freighter-repo': versions.eslintConfig,
-      'eslint-config-prettier': '5.0.0',
-      'eslint-plugin-flowtype': '3.10.3',
-      'eslint-plugin-prettier': '3.1.0',
-      'flow-typed': '2.5.2',
-      husky: '2.4.1',
-      lerna: '3.15.0',
-      'lint-staged': '8.2.1',
-      'flow-bin': '0.85.0',
+      // $FlowFixMe
+      'eslint-config-prettier': __VERSIONS__['eslint-config-prettier'],
+      // $FlowFixMe
+      'eslint-plugin-flowtype': __VERSIONS__['eslint-plugin-flowtype'],
+      // $FlowFixMe
+      'eslint-plugin-prettier': __VERSIONS__['eslint-plugin-prettier'],
+      // $FlowFixMe
+      'flow-typed': __VERSIONS__['flow-typed'],
+      // $FlowFixMe
+      husky: __VERSIONS__.husky,
+      // $FlowFixMe
+      lerna: __VERSIONS__.lerna,
+      // $FlowFixMe
+      'lint-staged': __VERSIONS__['lint-staged'],
+      // $FlowFixMe
+      'flow-bin': __VERSIONS__['flow-bin'],
     },
   });

--- a/prepare-packages
+++ b/prepare-packages
@@ -3,14 +3,19 @@ set -e
 
 function prepare_package {
   printf 'Compiling "%s"... ' "$(basename "$1")"
-  yarn -s babel "$1/src" -d "$1/dist" --ignore '**/__tests__' --copy-files
-  remove_test_files "$1"
+  local babel="$PWD/node_modules/.bin/babel"
+
+  (
+    cd "$1"
+    "$babel" src -d dist --ignore '**/__tests__' --copy-files
+    remove_test_files
+  )
 }
 
 # Babel 7 changed how `--ignore` behaves, causing `--copy-files` to rebel and
 # include test files and break coverage.
 function remove_test_files {
-  find "$1/dist" -type d -name __tests__ | while read -r test_dir; do
+  find dist -type d -name __tests__ | while read -r test_dir; do
     rm -rf "$test_dir"
   done
 }


### PR DESCRIPTION
Added a simple babel plugin to expose a `__VERSIONS__` global. If you
try to read from it, it'll replace the value at compile time with the
corresponding version from the monorepo package.json. It solves some
issues around duplicated version numbers making the upgrade process
tedious, error prone, and resistant to automation.